### PR TITLE
Errors when writing to the root directory.

### DIFF
--- a/chapters/intro_tfx/Apache_beam_example_notebook.ipynb
+++ b/chapters/intro_tfx/Apache_beam_example_notebook.ipynb
@@ -58,7 +58,7 @@
         "from apache_beam.options.pipeline_options import SetupOptions\n",
         "\n",
         "input_file = \"gs://dataflow-samples/shakespeare/kinglear.txt\"\n",
-        "output_file = \"/content/output.txt\"\n",
+        "output_file = \"./content/output.txt\"\n",
         "\n",
         "# TODO explain these lines\n",
         "pipeline_options = PipelineOptions()\n",
@@ -102,7 +102,7 @@
         "outputId": "fd19137c-52e4-4442-b597-b0a23a2bf3bb"
       },
       "source": [
-        "!head /content/output.txt*"
+        "!head ./content/output.txt*"
       ],
       "execution_count": 8,
       "outputs": [


### PR DESCRIPTION
Hi.  I found that writing to the root directory throws an error, at least on my Mac.  It might be safer and more obvious to write to the working directory.