### PR TITLE
Match tfx version in notebook with the one pinned in requirements.txt

### DIFF
--- a/interactive-pipeline/interactive_pipeline.ipynb
+++ b/interactive-pipeline/interactive_pipeline.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install tfx==0.21.4"
+    "!pip install tfx==0.22.0"
    ]
   },
   {


### PR DESCRIPTION
In requirements/requirements.txt the tfx version is pinned to version 0.22.0, but in the notebook, the version is pinned to 0.21.4.