### PR TITLE
Fix for interactive-pipeline Transformer and Trainer components.

### DIFF
--- a/components/module.py
+++ b/components/module.py
@@ -69,24 +69,6 @@ def convert_num_to_one_hot(
     return tf.reshape(one_hot_tensor, [-1, num_labels])
 
 
-def convert_zip_code(zipcode: str) -> tf.float32:
-    """
-    Convert a zipcode string to int64 representation. In the dataset the
-    zipcodes are anonymized by repacing the last 3 digits to XXX. We are
-    replacing those characters to 000 to simplify the bucketing later on.
-
-    Args:
-        str: zipcode
-    Returns:
-        zipcode: int64
-    """
-    if zipcode == "":
-        zipcode = "00000"
-    zipcode = tf.strings.regex_replace(zipcode, r"X{0,5}", "0")
-    zipcode = tf.strings.to_number(zipcode, out_type=tf.float32)
-    return zipcode
-
-
 def preprocessing_fn(inputs: tf.Tensor) -> tf.Tensor:
     """tf.transform's callback function for preprocessing inputs.
 
@@ -109,7 +91,7 @@ def preprocessing_fn(inputs: tf.Tensor) -> tf.Tensor:
 
     for key, bucket_count in BUCKET_FEATURES.items():
         temp_feature = tft.bucketize(
-            convert_zip_code(fill_in_missing(inputs[key])),
+            fill_in_missing(inputs[key]),
             bucket_count,
             always_return_num_quantiles=False,
         )

--- a/utils/download_dataset.py
+++ b/utils/download_dataset.py
@@ -102,9 +102,6 @@ def update_csv():
     df = pd.read_csv(LOCAL_FILE_NAME, usecols=feature_cols)
 
     df = df[df["consumer_complaint_narrative"].notnull()]
-    df["c"] = df["consumer_disputed"].map({"Yes": 1, "No": 0})
-    df = df.drop("consumer_disputed", axis=1)
-    df = df.rename(columns={"c": "consumer_disputed"})
     df = df.sample(frac=1, replace=False).reset_index(drop=True)
     df["zip_code"] = df["zip_code"].str.replace("XX", "00")
 


### PR DESCRIPTION
These commits address two issues brought up in #9 related to the interactive pipeline notebook. First, the `Transformer` component errors out because the `zip_code` field in the current upstream dataset is inferred as `INT` and `module.preprocessing_fn` attempts to process it as a string. Second, the `Trainer` component errors out because the upstream dataset has the `consumer_disputed` field already converted to {0,1} but `download_dataset.update_csv` attempts to do that again, resulting in `nan`s that the trainer chokes on.

I took a best guess at patches for both. I'm open for suggestions.